### PR TITLE
Changing the order of transfer's arguments to match credit & debit

### DIFF
--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -26,7 +26,7 @@ import (
 )
 
 var transferCmd = &cobra.Command{
-	Use:     "transfer {src} {dest} {amount}",
+	Use:     "transfer {amount} {src} {dest}",
 	Aliases: []string{"t", "tran"},
 	Short:   "Moves funds from one category of spending to another.",
 	Args:    cobra.ExactArgs(3),
@@ -34,9 +34,9 @@ var transferCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		rawSrc := args[0]
-		rawDest := args[1]
-		rawMagnitude := args[2]
+		rawSrc := args[1]
+		rawDest := args[2]
+		rawMagnitude := args[0]
 		magnitude, err := envelopes.ParseBalance(rawMagnitude)
 		if err != nil {
 			logrus.Fatal(err)


### PR DESCRIPTION
It was driving me crazy while distributing my paycheck this week. Definitely needs to be consistent with debit & credit in their current forms.