### PR TITLE
Making test-redhatify-version.sh agnostic to the current working directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ go.mod: ${SRC}
 test: .semaphores/test
 .semaphores/test: ${SRC} ${TEST_SRC}
 	go test ./...
-	bash -c "pushd ./packaging/redhat > /dev/null; ./test-redhatify-version.sh; result=\$$?; popd > /dev/null; exit \$${result}"
+	bash ./packaging/redhat/test-redhatify-version.sh
 	mkdir -p .semaphores && touch .semaphores/test
 
 .PHONY: lint

--- a/packaging/redhat/redhatify-version.pl
+++ b/packaging/redhat/redhatify-version.pl
@@ -4,8 +4,8 @@
 # This script takes a list of semantic versions and converts each to one that #
 # is an acceptable version name to embed into an RPM file name.               #
 #                                                                             #
-# Pragmatically, the difference is that RPM does not all the character `-` to #
-# be part of a version, whereas SemVer demands that the `-` be used for       #
+# Pragmatically, the difference is that RPM does not allow the character `-`  #
+# to be part of a version, whereas SemVer demands that the `-` be used for    #
 # defining a 'tag', and also allows the hyphen to be used inside of a tag.    #
 # Looking at popular projects, it seems the convention is to replace the `-`  #
 # with a `~`.                                                                 #

--- a/packaging/redhat/test-redhatify-version.sh
+++ b/packaging/redhat/test-redhatify-version.sh
@@ -9,7 +9,10 @@
 ###############################################################################
 
 set -e
+
+pushd $(dirname ${BASH_SOURCE[0]}) > /dev/null
 output_location=$(mktemp -t redhat_versions_XXXXXXXXXX.txt)
 cat ./testdata/semvers.txt | perl ./redhatify-version.pl > ${output_location}
 diff ./testdata/redhat-vers.txt ${output_location}
 rm ${output_location}
+popd > /dev/null


### PR DESCRIPTION
Moving `pushd` and `popd` into the script itself, and removing it from the Makefile.

Fixing some typos.