### PR TITLE
Rewrite build scripts in perl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ docker: bin/docker/baronial-alpine.tar.gz bin/docker/baronial-debian.tar.gz bin/
 rpm: bin/linux/baronial.fc29.src.rpm bin/linux/baronial.fc29.x86_64.rpm bin/linux/baronial.fc30.src.rpm bin/linux/baronial.fc30.x86_64.rpm bin/linux/baronial.lp151.src.rpm bin/linux/baronial.lp151.x86_64.rpm
 
 version.txt: ${SRC} go.sum
-	sh ./get-version.sh > version.txt
+	perl ./get-version.pl > version.txt
 
 revision.txt: ${SRC} go.sum
-	sh ./get-revision.sh > revision.txt
+	perl ./get-revision.pl > revision.txt
 
 # Define specific build targets.
 bin/darwin/baronial: ${SRC} go.sum version.txt revision.txt

--- a/ancestors.pl
+++ b/ancestors.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env perl
 
 ###############################################################################
 # This script enumerates all tags in the current repository that point to a   #
@@ -8,8 +8,15 @@
 # Output: A list of Git tag names.                                            #
 ###############################################################################
 
-for tag in $(git tag) ; do
-    if git merge-base --is-ancestor ${tag} HEAD; then
-        echo ${tag}
-    fi
-done
+use strict;
+use warnings FATAL => 'all';
+
+open(TAGS, "git tag|");
+
+while(my $tag = <TAGS>){
+    $tag =~ s/\s+$//;
+    system("git merge-base --is-ancestor ${tag} HEAD");
+    if($? == 0){
+        print($tag . "\n");
+    }
+}

--- a/get-revision.pl
+++ b/get-revision.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env perl
 
 ###############################################################################
 # This script finds the unique identifier for the current SCM revision.       #
@@ -12,10 +12,14 @@
 # commit, the suffix "-modified" is added"                                    #
 ###############################################################################
 
-revision="$(git rev-parse HEAD)"
+use strict;
+use warnings;
 
-if ! [[ -z "$(git status --short)" ]]; then
-	revision="${revision}-modified"
-fi
+my $revision = `git rev-parse HEAD`;
+$revision =~ s/\s+$//;
 
-echo "${revision}"
+if(`git status --short` ne ""){
+    $revision = $revision . "-modified";
+}
+
+print($revision);

--- a/get-version.pl
+++ b/get-version.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env perl
 
 ###############################################################################
 # This script finds the SemVer that would be most applicable to this code,    #
@@ -18,12 +18,16 @@
 # Git repository as part of this application.                                 #
 ###############################################################################
 
-version=$(./ancestors.sh | ./max-version.pl)
-revision=$(./get-revision.sh)
+use strict;
+use warnings FATAL => 'all';
 
+my $version = `./ancestors.pl | ./max-version.pl`;
+$version =~ s/\s+$//;
+my $revision = `./get-revision.pl`;
+$revision =~ s/\s+$//;
 
-if [[ $(git rev-parse ${version}) != ${revision} ]]; then
-    version="${version}-modified"
-fi
+if(`git rev-parse ${version}` ne $revision){
+    $version = $version . "-modified";
+}
 
-echo ${version}
+print($version);


### PR DESCRIPTION
This will make it easier to write a convenient Windows build script without having duplicate logic.