### PR TITLE
Add perl requirement to alpine Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ ARG alpine_version=3.9
 
 FROM golang:alpine${alpine_version} AS builder
 
-RUN apk add --no-cache --update alpine-sdk gcc make git
+RUN apk add --no-cache --update alpine-sdk gcc make git perl
 
 WORKDIR /usr/local/src/baronial
 


### PR DESCRIPTION
Fixing a bug where running `make docker` would fail for the alpine linux based container, now that the version scripts were rewritten in perl.