### PR TITLE
Adding `go mod download` caching layer to container builds.

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,8 +6,11 @@ RUN apk add --no-cache --update alpine-sdk gcc make git perl
 
 WORKDIR /usr/local/src/baronial
 
-COPY . .
+COPY go.* .
+
 RUN go mod download
+
+COPY . .
 
 RUN make install
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,6 +4,10 @@ FROM golang:${tag} AS builder
 
 WORKDIR /usr/local/src/baronial
 
+COPY go.* .
+
+RUN go mod download
+
 COPY . .
 
 RUN make bin/linux/baronial

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -7,6 +7,10 @@ RUN rpmdev-setuptree
 
 WORKDIR /usr/src/baronial
 
+COPY go.* .
+
+RUN go mod download
+
 ADD . .
 
 ARG release=1

--- a/Dockerfile.opensuse_leap
+++ b/Dockerfile.opensuse_leap
@@ -8,6 +8,10 @@ RUN rpmdev-setuptree
 
 WORKDIR /usr/src/baronial
 
+COPY go.* .
+
+RUN go mod download
+
 ADD . .
 
 ARG release=1


### PR DESCRIPTION
Downloading all of the go modules was the most expensive part of recurrent container builds on my machine. This reduces build time SIGNIFICANTLY. 