### PR TITLE
Create a new, independent build when tags are pushed.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+trigger:
+  branches:
+    include:
+      - '*'
+  tags:
+    include:
+      - '*'
+
 jobs:
 - job: Lint
   displayName: Ensure Formatting, Lint


### PR DESCRIPTION
This will allow for the release process to start by pushing a tag.