### PR TITLE
Remove "." character from entity name in log command

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -94,6 +94,7 @@ var logCmd = &cobra.Command{
 // containsEntity inspects an Impact, to see if any of the entities provided were impacted by a transaction.
 func containsEntity(diff envelopes.Impact, entities ...string) bool {
 	for _, entity := range entities {
+		entity = strings.TrimLeft(entity, ".")
 		entity = strings.TrimPrefix(entity, "/")
 		entity = strings.TrimPrefix(entity, "\\")
 


### PR DESCRIPTION
Fixes #40

Realistically, this should be refactored so that this logic doesn't live in the log command file. The bulk of it should probably live in [marstr/envelopes](https://github.com/marstr/envelopes), in [`state.go`](https://github.com/marstr/envelopes/blob/f278930ca025e4dabf1f82c236277cc21a5b5659/state.go) dangled off of `State` and `Impact`.