### PR TITLE
Updating envelopes dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/marstr/baronial
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/marstr/envelopes v0.0.0-20190818071432-1b58707a912e
+	github.com/marstr/envelopes v0.0.0-20190915204657-a43878a91415
 	github.com/marstr/units v1.0.1
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/marstr/envelopes v0.0.0-20190818055740-687d6b7ef3dd h1:F3spkU/nEO2eXB
 github.com/marstr/envelopes v0.0.0-20190818055740-687d6b7ef3dd/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
 github.com/marstr/envelopes v0.0.0-20190818071432-1b58707a912e h1:tv0ydp5zhHOjNSN5cKGKrycTl2sbOIcC/d8XtWfE2BM=
 github.com/marstr/envelopes v0.0.0-20190818071432-1b58707a912e/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
+github.com/marstr/envelopes v0.0.0-20190915204657-a43878a91415 h1:Y/C0J0uCkYj71+o5ycKIDHPdPXJxpxitxDi+FleMNZE=
+github.com/marstr/envelopes v0.0.0-20190915204657-a43878a91415/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=
 github.com/marstr/units v1.0.1/go.mod h1:B1/IxDKETT7FwLuU0ZOvdPePP9chjt0PLTt+qeVARJ8=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -18,12 +18,6 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/marstr/collection v1.0.1 h1:j61osRfyny7zxBlLRtoCvOZ2VX7HEyybkZcsLNLJ0z0=
 github.com/marstr/collection v1.0.1/go.mod h1:HHDXVxjLO3UYCBXJWY+J/ZrxCUOYqrO66ob1AzIsmYA=
-github.com/marstr/envelopes v0.0.0-20190818055447-de566971a6ef h1:HGUPXiaoI6coEiFdbiFuOIDUC0Ut2PqjmpFJ6apBz2k=
-github.com/marstr/envelopes v0.0.0-20190818055447-de566971a6ef/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
-github.com/marstr/envelopes v0.0.0-20190818055740-687d6b7ef3dd h1:F3spkU/nEO2eXB7pXmriCPZQ8c2MuleRIp3g1R6BWw0=
-github.com/marstr/envelopes v0.0.0-20190818055740-687d6b7ef3dd/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
-github.com/marstr/envelopes v0.0.0-20190818071432-1b58707a912e h1:tv0ydp5zhHOjNSN5cKGKrycTl2sbOIcC/d8XtWfE2BM=
-github.com/marstr/envelopes v0.0.0-20190818071432-1b58707a912e/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
 github.com/marstr/envelopes v0.0.0-20190915204657-a43878a91415 h1:Y/C0J0uCkYj71+o5ycKIDHPdPXJxpxitxDi+FleMNZE=
 github.com/marstr/envelopes v0.0.0-20190915204657-a43878a91415/go.mod h1:E+AJbWeG4QmcZnSQW2aII/Gw9XIumNhshpii+jHBkms=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=


### PR DESCRIPTION
Removes go1.12 requirement