### PR TITLE
Adopt go 1.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,9 @@ jobs:
 
   steps:
     - task: GoTool@0
-      displayName: 'Use Go 1.12'
+      displayName: 'Use Go 1.13'
       inputs:
-        version: 1.12
+        version: 1.13
     - script: |
         set -ev
         mkdir -p ~/go
@@ -48,9 +48,9 @@ jobs:
 
   steps:
   - task: GoTool@0
-    displayName: 'Use Go 1.12'
+    displayName: 'Use Go 1.13'
     inputs:
-      version: 1.12
+      version: 1.13
   - script: |
       go mod download
     displayName: 'Download Go Dependencies'
@@ -88,9 +88,9 @@ jobs:
 
   steps:
   - task: GoTool@0
-    displayName: 'Use Go 1.12'
+    displayName: 'Use Go 1.13'
     inputs:
-      version: 1.12
+      version: 1.13
   - script: |
       go mod download
     displayName: 'Download Dependencies'

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480 // indirect
 	golang.org/x/sys v0.0.0-20190419153524-e8e3143a4f4a // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Hoping this fixes the ADO issue blocking the Windows build. Otherwise, still nice to upgrade Go.