### PR TITLE
Diff cmd

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -38,16 +38,16 @@ type diffCmd struct {
 }
 
 func init() {
-	diff := NewDiffCmd()
+	diff := newDiffCmd()
 
 	rootCmd.AddCommand(&diff.Command)
 }
 
-func NewDiffCmd() *diffCmd {
-	return NewDiffCmdWithContext(context.Background())
+func newDiffCmd() *diffCmd {
+	return newDiffCmdWithContext(context.Background())
 }
 
-func NewDiffCmdWithContext(ctx context.Context) *diffCmd {
+func newDiffCmdWithContext(ctx context.Context) *diffCmd {
 	retval := &diffCmd{
 		Context: ctx,
 	}
@@ -119,13 +119,13 @@ func getDiffStates(ctx context.Context, args []string, indexRoot string) (*envel
 	}
 
 	loadFromRepository := func(ctx context.Context, rs persist.RefSpec) (*envelopes.State, error) {
-		var targetId envelopes.ID
-		targetId, err = resolver.Resolve(ctx, rs)
+		var targetID envelopes.ID
+		targetID, err = resolver.Resolve(ctx, rs)
 		if err != nil {
 			return nil, err
 		}
 		var target envelopes.Transaction
-		err = loader.Load(ctx, targetId, &target)
+		err = loader.Load(ctx, targetID, &target)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2020 Martin Strobel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/marstr/envelopes"
+	"github.com/marstr/envelopes/persist"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/marstr/baronial/internal/index"
+)
+
+type diffCmd struct {
+	cobra.Command
+	Context context.Context
+	Resolver persist.RefSpecResolver
+}
+
+func init() {
+	diff := NewDiffCmd()
+
+	rootCmd.AddCommand(&diff.Command)
+}
+
+func NewDiffCmd() *diffCmd {
+	return NewDiffCmdWithContext(context.Background())
+}
+
+func NewDiffCmdWithContext(ctx context.Context) *diffCmd {
+	retval := &diffCmd{
+		Context: ctx,
+	}
+
+	retval.Command = cobra.Command{
+		Use: "diff [refspec] [refspec]",
+		Short: "Finds the difference between two states, be they from the index or two transactions.",
+		Long: ``,
+		Args: retval.processArgs,
+		PreRunE: setPagedCobraOutput,
+		Run: retval.run,
+	}
+
+	return retval
+}
+
+func (dc diffCmd) processArgs(cmd *cobra.Command, arg []string) error {
+	if err := cobra.MaximumNArgs(2)(cmd, arg); err != nil {
+		return err
+	}
+
+	for _, rs := range arg {
+		id, err := dc.Resolver.Resolve(dc.Context, persist.RefSpec(rs))
+		if err != nil || id.Equal(envelopes.ID{}){
+			return fmt.Errorf("%q is not a valid refspec", rs)
+		}
+	}
+	return nil
+}
+
+func (dc diffCmd) run(cmd *cobra.Command, args []string) {
+	var err error
+	defer func(){
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
+	var repoRoot string
+	repoRoot, err = index.RootDirectory(".")
+	if err != nil {
+		return
+	}
+
+	left, right, err := getDiffStates(dc.Context, args, repoRoot)
+	if err != nil {
+		return
+	}
+
+	diff := left.Subtract(*right)
+
+	err = prettyPrintImpact(cmd.OutOrStdout(), diff)
+	if err != nil {
+		return
+	}
+}
+
+func getDiffStates(ctx context.Context, args []string, indexRoot string) (*envelopes.State, *envelopes.State, error) {
+	var err error
+	var left, right *envelopes.State
+	fs := persist.FileSystem{Root: path.Join(indexRoot, index.RepoName)}
+	loader := persist.DefaultLoader{
+		Fetcher: fs,
+	}
+	resolver := persist.RefSpecResolver{
+		Loader:   loader,
+		Brancher: fs,
+		Fetcher:  fs,
+	}
+
+	loadFromRepository := func(ctx context.Context, rs persist.RefSpec) (*envelopes.State, error) {
+		var targetId envelopes.ID
+		targetId, err = resolver.Resolve(ctx, rs)
+		if err != nil {
+			return nil, err
+		}
+		var target envelopes.Transaction
+		err = loader.Load(ctx, targetId, &target)
+		if err != nil {
+			return nil, err
+		}
+		return target.State, nil
+	}
+
+	index.LoadState(ctx, indexRoot)
+	switch len(args) {
+	case 0: // Compare current index against HEAD
+		right, err = loadFromRepository(ctx, persist.MostRecentTransactionAlias)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		left, err = index.LoadState(ctx, indexRoot)
+		if err != nil{
+			return nil, nil, err
+		}
+	case 1: // Compare current index against specified refspec
+		right, err = loadFromRepository(ctx, persist.RefSpec(args[0]))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		left, err = index.LoadState(ctx, indexRoot)
+		if err != nil {
+			return nil, nil, err
+		}
+	case 2: // Compare the two arbitrary refspecs
+		right, err = loadFromRepository(ctx, persist.RefSpec(args[0]))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		left, err = loadFromRepository(ctx, persist.RefSpec(args[0]))
+		if err != nil {
+			return nil, nil, err
+		}
+	default:
+		return nil, nil, errors.New("too many arguments")
+	}
+
+	return left, right, nil
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -82,7 +82,8 @@ func (dc diffCmd) run(cmd *cobra.Command, args []string) {
 	var err error
 	defer func(){
 		if err != nil {
-			logrus.Fatal(err)
+			logrus.Error(err)
+			return
 		}
 	}()
 
@@ -92,7 +93,8 @@ func (dc diffCmd) run(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	left, right, err := getDiffStates(dc.Context, args, repoRoot)
+	var left, right *envelopes.State
+	left, right, err = getDiffStates(dc.Context, args, repoRoot)
 	if err != nil {
 		return
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -57,6 +57,9 @@ var logCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		var output io.Writer
+		output, err = getPageWriter(ctx)
+
 		for !isEmptyID(currentID) {
 			// TODO: refactor so that if parent was already loaded below, current re-uses that pre-loaded instance.
 			var current envelopes.Transaction
@@ -80,7 +83,7 @@ var logCmd = &cobra.Command{
 			}
 
 			if len(args) == 0 || containsEntity(diff, args...) {
-				err = outputTransaction(ctx, pagedOutput, current)
+				err = outputTransaction(ctx, output, current)
 				if err != nil {
 					logrus.Fatal(err)
 				}

--- a/cmd/paged_output.go
+++ b/cmd/paged_output.go
@@ -12,37 +12,34 @@ import (
 
 var pagedOutput io.Writer = os.Stdout
 
-func init() {
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		if result, err := getPageWriter(context.Background()); err == nil {
-			pagedOutput = result
-		}
-	}
-}
 
 func getPageWriter(ctx context.Context) (io.Writer, error) {
-	var err error
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		var err error
 
-	if pagingPrograms == nil || len(pagingPrograms) == 0 {
-		return os.Stdout, errors.New("unrecognized platform, skipping paging")
+		if pagingPrograms == nil || len(pagingPrograms) == 0 {
+			return os.Stdout, errors.New("unrecognized platform, skipping paging")
+		}
+
+		for _, cmd := range pagingPrograms {
+			_, err = exec.LookPath(cmd.Path);
+			if err != nil {
+				continue
+			}
+			var retval io.Writer
+			wrappedCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args...)
+			wrappedCmd.Stdout = os.Stdout
+			retval, err = wrappedCmd.StdinPipe()
+			if err != nil {
+				return os.Stdout, err
+			}
+			wrappedCmd.Start()
+
+			return retval, nil
+		}
+
+		return os.Stdout, errors.New("no paging programs found")
 	}
 
-	for _, cmd := range pagingPrograms {
-		_, err = exec.LookPath(cmd.Path);
-		if err != nil {
-			continue
-		}
-		var retval io.Writer
-		wrappedCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args...)
-		wrappedCmd.Stdout = os.Stdout
-		retval, err = wrappedCmd.StdinPipe()
-		if err != nil {
-			return os.Stdout, err
-		}
-		wrappedCmd.Start()
-
-		return retval, nil
-	}
-
-	return os.Stdout, errors.New("no paging programs found")
+	return os.Stdout, nil
 }

--- a/cmd/paged_output.go
+++ b/cmd/paged_output.go
@@ -1,45 +1,86 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var pagedOutput io.Writer = os.Stdout
+func setPagedCobraOutput(cmd *cobra.Command, _ []string) error {
+	output, err := NewPageWriteCloser(os.Stdout, os.Stderr)
+	if err != nil {
+		return err
+	}
+	cmd.SetOutput(output)
+	cmd.PostRunE = func(cmd *cobra.Command, args []string) error {
+		return output.Close()
+	}
+	return nil
+}
 
-
-func getPageWriter(ctx context.Context) (io.Writer, error) {
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+func NewPageWriteCloser(outFile *os.File, errFile *os.File) (io.WriteCloser, error) {
+	retval := &PageWriteCloser{}
+	if terminal.IsTerminal(int(outFile.Fd())) {
 		var err error
-
 		if pagingPrograms == nil || len(pagingPrograms) == 0 {
-			return os.Stdout, errors.New("unrecognized platform, skipping paging")
+			return nil, errors.New("unrecognized platform, skipping paging")
 		}
 
 		for _, cmd := range pagingPrograms {
-			_, err = exec.LookPath(cmd.Path);
-			if err != nil {
+			if _, err = exec.LookPath(cmd.Path); err != nil {
 				continue
 			}
-			var retval io.Writer
-			wrappedCmd := exec.CommandContext(ctx, cmd.Path, cmd.Args...)
-			wrappedCmd.Stdout = os.Stdout
-			retval, err = wrappedCmd.StdinPipe()
+
+			retval.childProc = exec.Command(cmd.Path, cmd.Args...)
+			retval.childProc.Stdout = outFile
+			retval.childProc.Stderr = errFile
+			retval.handle, err = retval.childProc.StdinPipe()
 			if err != nil {
-				return os.Stdout, err
+				return nil, err
 			}
-			wrappedCmd.Start()
-
-			return retval, nil
+			break
 		}
-
-		return os.Stdout, errors.New("no paging programs found")
+	} else {
+		retval.handle = outFile
 	}
 
-	return os.Stdout, nil
+	return retval, nil
+}
+
+type PageWriteCloser struct {
+	procStart sync.Once
+	handle io.WriteCloser
+	childProc *exec.Cmd
+}
+
+func (pwc *PageWriteCloser) Write(p []byte) (int, error) {
+	var err error
+	pwc.procStart.Do(func(){
+		if pwc.childProc != nil{
+			err = pwc.childProc.Start();
+		}
+	})
+	if err != nil {
+		return 0, err
+	}
+	return pwc.handle.Write(p)
+}
+
+func (pwc *PageWriteCloser) Close() error {
+	err := pwc.handle.Close()
+	if err != nil {
+		return err
+	}
+	if pwc.childProc != nil {
+		err = pwc.childProc.Wait()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/paged_output_unixy.go
+++ b/cmd/paged_output_unixy.go
@@ -8,9 +8,6 @@ import (
 
 var pagingPrograms = []exec.Cmd{
 	{
-		Path: "less",
-	},
-	{
 		Path: "more",
 	},
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -114,9 +114,21 @@ func prettyPrintTransaction(
 	fmt.Fprintf(output, "Comment: \t%s\n", subject.Comment)
 	fmt.Fprintf(output, "Impacts:\n")
 
-	fmt.Fprintf(output, "\tAccounts:\n")
+	prettyPrintImpact(output, impacts)
+
+	return nil
+}
+
+func prettyPrintImpact(output io.Writer, impacts envelopes.Impact) (err error) {
+	_ , err = fmt.Fprintf(output, "\tAccounts:\n")
+	if err != nil {
+		return
+	}
 	for acc, delta := range impacts.Accounts {
-		fmt.Fprintf(output, "\t\t%s: %s\n", acc, delta)
+		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", acc, delta)
+		if err != nil {
+			return
+		}
 	}
 
 	flattened := flattenBudgets(impacts)
@@ -127,12 +139,15 @@ func prettyPrintTransaction(
 	}
 	sort.Strings(sortedBudgetNames)
 
-	fmt.Fprintf(output, "\tBudgets:\n")
+	_ , err = fmt.Fprintf(output, "\tBudgets:\n")
 	for _, name := range sortedBudgetNames {
-		fmt.Fprintf(output, "\t\t%s: %s\n", name, flattened[name])
+		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", name, flattened[name])
+		if err != nil {
+			return
+		}
 	}
 
-	return nil
+	return
 }
 
 func flattenBudgets(diff envelopes.Impact) map[string]envelopes.Balance {


### PR DESCRIPTION
Adding a `diff` command which allows for users to compare the state of their accounts between different transactions, or compare the current index with a Transaction's state.