### PR TITLE
Use Envelopes 0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/marstr/baronial
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/marstr/envelopes v0.2.0
+	github.com/marstr/envelopes v0.2.1
 	github.com/marstr/units v1.0.1
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/marstr/collection v1.0.1 h1:j61osRfyny7zxBlLRtoCvOZ2VX7HEyybkZcsLNLJ0z0=
 github.com/marstr/collection v1.0.1/go.mod h1:HHDXVxjLO3UYCBXJWY+J/ZrxCUOYqrO66ob1AzIsmYA=
-github.com/marstr/envelopes v0.2.0 h1:5ivAsxXJc8t9LJz1i7CKJFKEdW81eDgFRB5IjHTIjqI=
-github.com/marstr/envelopes v0.2.0/go.mod h1:Fgfk7O6FXSoONxPFZuxNIDNf0nZW1EkWZOHLYE8S6f0=
 github.com/marstr/envelopes v0.2.1 h1:YBjHf/9B3iP7SI8vxrj+MDW8poirIwD6mnLOP0kU1MA=
 github.com/marstr/envelopes v0.2.1/go.mod h1:Fgfk7O6FXSoONxPFZuxNIDNf0nZW1EkWZOHLYE8S6f0=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/marstr/collection v1.0.1 h1:j61osRfyny7zxBlLRtoCvOZ2VX7HEyybkZcsLNLJ0
 github.com/marstr/collection v1.0.1/go.mod h1:HHDXVxjLO3UYCBXJWY+J/ZrxCUOYqrO66ob1AzIsmYA=
 github.com/marstr/envelopes v0.2.0 h1:5ivAsxXJc8t9LJz1i7CKJFKEdW81eDgFRB5IjHTIjqI=
 github.com/marstr/envelopes v0.2.0/go.mod h1:Fgfk7O6FXSoONxPFZuxNIDNf0nZW1EkWZOHLYE8S6f0=
+github.com/marstr/envelopes v0.2.1 h1:YBjHf/9B3iP7SI8vxrj+MDW8poirIwD6mnLOP0kU1MA=
+github.com/marstr/envelopes v0.2.1/go.mod h1:Fgfk7O6FXSoONxPFZuxNIDNf0nZW1EkWZOHLYE8S6f0=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=
 github.com/marstr/units v1.0.1/go.mod h1:B1/IxDKETT7FwLuU0ZOvdPePP9chjt0PLTt+qeVARJ8=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
Notably - this fixes a bug that prevented parsing/usage of multi-asset type balances.