### PR TITLE
Add perl dependency for RPM builds

### DIFF
--- a/packaging/redhat/baronial.spec
+++ b/packaging/redhat/baronial.spec
@@ -6,8 +6,7 @@ License: GPLv3
 Source0: ./baronial-%{rpm_version}.tar.gz
 
 %define debug_package %{nil}
-
-BuildRequires: make go git
+BuildRequires: make go git perl
 
 %prep
 %setup -q -n baronial-%{raw_version}


### PR DESCRIPTION
This is a dependency that needs to be there to resolve version numbers, etc. It's a pretty ubiquitous package so there haven't been any complaints so far, but it's good to get it out in the world.