### PR TITLE
Add a Unique Bank Identifier to Transactions

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -78,6 +78,13 @@ const (
 	forceUsage     = "Ignore warnings, commit the transaction anyway."
 )
 
+const (
+	bankRecordIdFlag = "bank-record-id"
+	bankRecordIdShorthand = "b"
+	bankRecordIdDefault = ""
+	bankRecordIdUsage = "A unique ID assigned to this transaction by a financial institution."
+)
+
 var commitConfig = viper.New()
 
 var commitCmd = &cobra.Command{
@@ -195,6 +202,7 @@ var commitCmd = &cobra.Command{
 			Amount:   amount,
 			Merchant: commitConfig.GetString(merchantFlag),
 			Comment:  commitConfig.GetString(commentFlag),
+			RecordId: envelopes.BankRecordID(commitConfig.GetString(bankRecordIdFlag)),
 			State: &envelopes.State{
 				Accounts: accounts,
 				Budget:   budget,
@@ -234,6 +242,7 @@ func init() {
 	commitCmd.PersistentFlags().StringP(postedTimeFlag, postedTimeShorthand, postedTimeDefault, postedTimeUsage)
 	commitCmd.PersistentFlags().StringP(actualTimeFlag, actualTimeShorthand, actualTimeDefault, actualTimeUsage)
 	commitCmd.PersistentFlags().StringP(amountFlag, amountShorthand, commitConfig.GetString(amountFlag), amountUsage)
+	commitCmd.PersistentFlags().StringP(bankRecordIdFlag, bankRecordIdShorthand, bankRecordIdDefault, bankRecordIdUsage)
 	commitCmd.PersistentFlags().BoolP(forceFlag, forceShorthand, forceDefault, forceUsage)
 
 	err := commitConfig.BindPFlags(commitCmd.PersistentFlags())

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/marstr/baronial/internal/format"
 	"github.com/marstr/baronial/internal/index"
 )
 
@@ -101,7 +102,7 @@ func (dc diffCmd) run(cmd *cobra.Command, args []string) {
 
 	diff := left.Subtract(*right)
 
-	err = prettyPrintImpact(cmd.OutOrStdout(), diff)
+	err = format.PrettyPrintImpact(cmd.OutOrStdout(), diff)
 	if err != nil {
 		return
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -19,18 +19,16 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/marstr/envelopes"
 	"github.com/marstr/envelopes/persist"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/marstr/baronial/internal/format"
 	"github.com/marstr/baronial/internal/index"
 )
 
@@ -101,7 +99,7 @@ var logCmd = &cobra.Command{
 			}
 
 			if len(args) == 0 || containsEntity(diff, args...) {
-				err = outputTransaction(ctx, cmd.OutOrStdout(), current)
+				err = format.ConcisePrintTransaction(ctx, cmd.OutOrStdout(), current)
 				if err != nil {
 					if cast, ok := err.(*os.PathError); ok {
 						if cast.Path == "|1" {
@@ -177,43 +175,7 @@ func isEmptyID(subject envelopes.ID) bool {
 	return true
 }
 
-func outputTransaction(_ context.Context, output io.Writer, subject envelopes.Transaction) (err error) {
-	_, err = fmt.Fprintln(output, subject.ID())
-	if err != nil {
-		return
-	}
-	if !subject.ActualTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "\tActual Time:    \t%v\n", subject.ActualTime)
-		if err != nil {
-			return
-		}
-	}
-	if !subject.PostedTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "\tPosted Time:    \t%v\n", subject.PostedTime)
-		if err != nil {
-			return
-		}
-	}
-	if !subject.EnteredTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "\tEntered Time:    \t%v\n", subject.EnteredTime)
-		if err != nil {
-			return
-		}
-	}
-	_, err = fmt.Fprintf(output, "\tAmount:  \t%s\n", subject.Amount)
-	if err != nil {
-		return
-	}
-	_, err = fmt.Fprintf(output, "\tMerchant:\t%s\n", subject.Merchant)
-	if err != nil {
-		return
-	}
-	_, err = fmt.Fprintf(output, "\tComment: \t%s\n", subject.Comment)
-	if err != nil {
-		return
-	}
-	return nil
-}
+
 
 func init() {
 	rootCmd.AddCommand(logCmd)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -17,18 +17,15 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"os"
 	"path"
-	"sort"
-	"time"
 
 	"github.com/marstr/envelopes"
 	"github.com/marstr/envelopes/persist"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/marstr/baronial/internal/format"
 	"github.com/marstr/baronial/internal/index"
 )
 
@@ -76,7 +73,7 @@ for the sake of brevity. This command shows all known details of a transaction.`
 			logrus.Fatal(err)
 		}
 
-		err = prettyPrintTransaction(ctx, os.Stdout, loader, target)
+		err = format.PrettyPrintTransaction(ctx, os.Stdout, loader, target)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -85,123 +82,4 @@ for the sake of brevity. This command shows all known details of a transaction.`
 
 func init() {
 	rootCmd.AddCommand(showCmd)
-}
-
-// prettyPrintTransaction serializes a transaction into text in as pretty of a fashion as it can muster. It requires a
-// `persist.Loader` in order to fetch any budget related information in its pursuit. Most notably, it must fetch the
-// parent of this transaction to figure out the differences to each budget/account.
-func prettyPrintTransaction(
-	ctx context.Context,
-	output io.Writer,
-	loader persist.Loader,
-	subject envelopes.Transaction) error {
-	var err error
-	var impacts envelopes.Impact
-
-	if subject.Parent.Equal(envelopes.ID{}) {
-		impacts = envelopes.Impact(*subject.State)
-	} else {
-		var parent envelopes.Transaction
-		err := loader.Load(ctx, subject.Parent, &parent)
-		if err != nil {
-			return err
-		}
-		impacts = subject.State.Subtract(*parent.State)
-	}
-
-	if !subject.ActualTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "Actual Time:    \t%s\n", subject.ActualTime)
-		if err != nil {
-			return err
-		}
-	}
-	if !subject.PostedTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "Posted Time:    \t%s\n", subject.PostedTime)
-		if err != nil {
-			return err
-		}
-	}
-	if !subject.EnteredTime.Equal(time.Time{}) {
-		_, err = fmt.Fprintf(output, "Entered Time:    \t%s\n", subject.EnteredTime)
-		if err != nil {
-			return err
-		}
-	}
-	_, err = fmt.Fprintf(output, "Merchant:\t%s\n", subject.Merchant)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(output, "Amount:  \t%s\n", subject.Amount)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(output, "Parent:  \t%s\n", subject.Parent)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(output, "Comment: \t%s\n", subject.Comment)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(output, "Impacts:\n")
-	if err != nil {
-		return err
-	}
-
-	return prettyPrintImpact(output, impacts)
-}
-
-func prettyPrintImpact(output io.Writer, impacts envelopes.Impact) (err error) {
-	_ , err = fmt.Fprintf(output, "\tAccounts:\n")
-	if err != nil {
-		return
-	}
-	for acc, delta := range impacts.Accounts {
-		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", acc, delta)
-		if err != nil {
-			return
-		}
-	}
-
-	flattened := flattenBudgets(impacts)
-
-	sortedBudgetNames := make([]string, 0, len(flattened))
-	for name := range flattened {
-		sortedBudgetNames = append(sortedBudgetNames, name)
-	}
-	sort.Strings(sortedBudgetNames)
-
-	_ , err = fmt.Fprintf(output, "\tBudgets:\n")
-	for _, name := range sortedBudgetNames {
-		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", name, flattened[name])
-		if err != nil {
-			return
-		}
-	}
-
-	return
-}
-
-func flattenBudgets(diff envelopes.Impact) map[string]envelopes.Balance {
-	retval := make(map[string]envelopes.Balance)
-	var helper func(*envelopes.Budget, string, string)
-	helper = func(current *envelopes.Budget, running, name string) {
-		if current == nil {
-			return
-		}
-
-		fullName := path.Join(running, name)
-
-		if !current.Balance.Equal(envelopes.Balance{}) {
-			retval[fullName] = current.Balance
-		}
-
-		for childName, child := range current.Children {
-			helper(child, fullName, childName)
-		}
-	}
-
-	helper(diff.Budget, "", "")
-
-	return retval
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/marstr/baronial
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/marstr/envelopes v0.2.2
+	github.com/marstr/envelopes v0.2.4
 	github.com/marstr/units v1.0.1
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/marstr/collection v1.0.1 h1:j61osRfyny7zxBlLRtoCvOZ2VX7HEyybkZcsLNLJ0z0=
-github.com/marstr/collection v1.0.1/go.mod h1:HHDXVxjLO3UYCBXJWY+J/ZrxCUOYqrO66ob1AzIsmYA=
-github.com/marstr/envelopes v0.2.2 h1:mGDxcFajKMbXYXCQz+sWOEHpwTIIjgWm/Bjk3Zvp/Qo=
-github.com/marstr/envelopes v0.2.2/go.mod h1:Fgfk7O6FXSoONxPFZuxNIDNf0nZW1EkWZOHLYE8S6f0=
+github.com/marstr/collection v1.1.1 h1:NJgrWXrjYWkrAr/bAp6LVCT+NvrZpE8URGFy7R7CBIA=
+github.com/marstr/collection v1.1.1/go.mod h1:yGFnCtb7iWtkdragXuuvnQzBQ8DAu+awhmE7F4kRgaQ=
+github.com/marstr/envelopes v0.2.4 h1:49yL/tB4/+Xkz78MRsCO1IsZciPkrrNqV9ZyCGgiwoI=
+github.com/marstr/envelopes v0.2.4/go.mod h1:oGPRhVzOhygr7Zfmjw6sLVb22K3yPm/TWuuF3u8QVf8=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=
 github.com/marstr/units v1.0.1/go.mod h1:B1/IxDKETT7FwLuU0ZOvdPePP9chjt0PLTt+qeVARJ8=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/internal/format/transaction.go
+++ b/internal/format/transaction.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2020 Martin Strobel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package format
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"time"
+
+	"github.com/marstr/envelopes"
+	"github.com/marstr/envelopes/persist"
+)
+
+func ConcisePrintTransaction(_ context.Context, output io.Writer, subject envelopes.Transaction) (err error) {
+	_, err = fmt.Fprintln(output, subject.ID())
+	if err != nil {
+		return
+	}
+	if !subject.ActualTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "\tActual Time:    \t%v\n", subject.ActualTime)
+		if err != nil {
+			return
+		}
+	}
+	if !subject.PostedTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "\tPosted Time:    \t%v\n", subject.PostedTime)
+		if err != nil {
+			return
+		}
+	}
+	if !subject.EnteredTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "\tEntered Time:    \t%v\n", subject.EnteredTime)
+		if err != nil {
+			return
+		}
+	}
+	_, err = fmt.Fprintf(output, "\tAmount:  \t%s\n", subject.Amount)
+	if err != nil {
+		return
+	}
+	_, err = fmt.Fprintf(output, "\tMerchant:\t%s\n", subject.Merchant)
+	if err != nil {
+		return
+	}
+	_, err = fmt.Fprintf(output, "\tComment: \t%s\n", subject.Comment)
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+// prettyPrintTransaction serializes a transaction into text in as pretty of a fashion as it can muster. It requires a
+// `persist.Loader` in order to fetch any budget related information in its pursuit. Most notably, it must fetch the
+// parent of this transaction to figure out the differences to each budget/account.
+func PrettyPrintTransaction(
+	ctx context.Context,
+	output io.Writer,
+	loader persist.Loader,
+	subject envelopes.Transaction) error {
+	var err error
+	var impacts envelopes.Impact
+
+	if subject.Parent.Equal(envelopes.ID{}) {
+		impacts = envelopes.Impact(*subject.State)
+	} else {
+		var parent envelopes.Transaction
+		err := loader.Load(ctx, subject.Parent, &parent)
+		if err != nil {
+			return err
+		}
+		impacts = subject.State.Subtract(*parent.State)
+	}
+
+	if !subject.ActualTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "Actual Time:    \t%s\n", subject.ActualTime)
+		if err != nil {
+			return err
+		}
+	}
+	if !subject.PostedTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "Posted Time:    \t%s\n", subject.PostedTime)
+		if err != nil {
+			return err
+		}
+	}
+	if !subject.EnteredTime.Equal(time.Time{}) {
+		_, err = fmt.Fprintf(output, "Entered Time:    \t%s\n", subject.EnteredTime)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(output, "Merchant:\t%s\n", subject.Merchant)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "Amount:  \t%s\n", subject.Amount)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "Parent:  \t%s\n", subject.Parent)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "Comment: \t%s\n", subject.Comment)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "Impacts:\n")
+	if err != nil {
+		return err
+	}
+
+	return PrettyPrintImpact(output, impacts)
+}
+
+func PrettyPrintImpact(output io.Writer, impacts envelopes.Impact) (err error) {
+	_ , err = fmt.Fprintf(output, "\tAccounts:\n")
+	if err != nil {
+		return
+	}
+	for acc, delta := range impacts.Accounts {
+		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", acc, delta)
+		if err != nil {
+			return
+		}
+	}
+
+	flattened := flattenBudgets(impacts)
+
+	sortedBudgetNames := make([]string, 0, len(flattened))
+	for name := range flattened {
+		sortedBudgetNames = append(sortedBudgetNames, name)
+	}
+	sort.Strings(sortedBudgetNames)
+
+	_ , err = fmt.Fprintf(output, "\tBudgets:\n")
+	for _, name := range sortedBudgetNames {
+		_ , err = fmt.Fprintf(output, "\t\t%s: %s\n", name, flattened[name])
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func flattenBudgets(diff envelopes.Impact) map[string]envelopes.Balance {
+	retval := make(map[string]envelopes.Balance)
+	var helper func(*envelopes.Budget, string, string)
+	helper = func(current *envelopes.Budget, running, name string) {
+		if current == nil {
+			return
+		}
+
+		fullName := path.Join(running, name)
+
+		if !current.Balance.Equal(envelopes.Balance{}) {
+			retval[fullName] = current.Balance
+		}
+
+		for childName, child := range current.Children {
+			helper(child, fullName, childName)
+		}
+	}
+
+	helper(diff.Budget, "", "")
+
+	return retval
+}

--- a/internal/format/transaction.go
+++ b/internal/format/transaction.go
@@ -60,6 +60,12 @@ func ConcisePrintTransaction(_ context.Context, output io.Writer, subject envelo
 	if err != nil {
 		return
 	}
+	if subject.RecordId != "" {
+		_, err = fmt.Fprintf(output, "\tBank Record ID:\t%s\n", subject.RecordId)
+		if err != nil {
+			return err
+		}
+	}
 	_, err = fmt.Fprintf(output, "\tComment: \t%s\n", subject.Comment)
 	if err != nil {
 		return
@@ -110,6 +116,12 @@ func PrettyPrintTransaction(
 	_, err = fmt.Fprintf(output, "Merchant:\t%s\n", subject.Merchant)
 	if err != nil {
 		return err
+	}
+	if subject.RecordId != "" {
+		_, err = fmt.Fprintf(output, "Bank Record ID:\t%s\n", subject.RecordId)
+		if err != nil {
+			return err
+		}
 	}
 	_, err = fmt.Fprintf(output, "Amount:  \t%s\n", subject.Amount)
 	if err != nil {


### PR DESCRIPTION
This adds a new parameter `--bank-record-id` to the `commit` command, and extends all `Transaction` display to include this metadata.