### PR TITLE
Add Commands to lookup Transactions by Bank Unique Identifier

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -202,7 +202,7 @@ var commitCmd = &cobra.Command{
 			Amount:   amount,
 			Merchant: commitConfig.GetString(merchantFlag),
 			Comment:  commitConfig.GetString(commentFlag),
-			RecordId: envelopes.BankRecordID(commitConfig.GetString(bankRecordIdFlag)),
+			RecordID: envelopes.BankRecordID(commitConfig.GetString(bankRecordIdFlag)),
 			State: &envelopes.State{
 				Accounts: accounts,
 				Budget:   budget,

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -174,8 +174,14 @@ var commitCmd = &cobra.Command{
 			Root: filepath.Join(targetDir, index.RepoName),
 		}
 
-		writer := persist.DefaultWriter{
+		var writer persist.Writer
+		writer = persist.DefaultWriter{
 			Stasher: persister,
+		}
+		
+		writer = persist.FilesystemBankRecordIDIndex{
+			Root:            filepath.Join(persister.Root, "indices", "bank_record_id"),
+			DecoratedWriter: writer,
 		}
 
 		loader := persist.DefaultLoader{

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Martin Strobel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// indexCmd represents the index command
+var indexCmd = &cobra.Command{
+	Use:   "index",
+	Short: "Lookup transaction IDs.",
+	Long: `Offers utilities to find transactions quickly. Combined with the command
+'baronial show', this can be a powerful way to quickly find details
+instead of scrolling through relatively verbose transaction logs.`,
+}
+
+func init() {
+	rootCmd.AddCommand(indexCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// indexCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// indexCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/index_bank_record_id.go
+++ b/cmd/index_bank_record_id.go
@@ -1,0 +1,103 @@
+/*
+Copyright © 2020 Martin Strobel
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/marstr/envelopes/persist"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/marstr/baronial/internal/index"
+	"github.com/marstr/baronial/internal/repository"
+)
+
+const (
+	briOutputFlag = "output-format"
+	briOutputShorthand = "f"
+	briOutputDefault = "none"
+	briOutputUsage = "How relevant transaction ID should be relayed."
+)
+
+var briSupportedOutputFormats = map[string]struct{}{
+	"none": {},
+}
+
+var bankRecordIdConfig = viper.New()
+
+// bankRecordIdCmd represents the bankRecordId command
+var bankRecordIdCmd = &cobra.Command{
+	Use:   "bank-record-id",
+	Aliases: []string{"bri"},
+	Short: "Find Transactions by bank assigned Record ID",
+	Long: `Looks up transactions associated with a unique identifier
+associated with a unique identifier assigned by a financial institution.
+
+Status Code:
+
+When no transactions are associated with the given bank record ID, the exit
+status code will be set to 1. If even one transaction is associated with the
+bank's identifier, the exit status will be 0.'
+
+Output Format:
+
+none -> Only the exit status code will be set.
+any -> Prints "true" if any transactions are associated with it, "false" otherwise.
+`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		chosenOutput := bankRecordIdConfig.GetString(briOutputFlag)
+		if _, ok := briSupportedOutputFormats[chosenOutput]; !ok {
+			return fmt.Errorf("unrecognized %s option provided: %q", briOutputFlag, chosenOutput)
+		}
+		return cobra.MaximumNArgs(1)(cmd, args)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		var rootDir string
+		var err error
+		rootDir, err = index.RootDirectory(".")
+		if err != nil {
+			logrus.Error(err)
+		}
+
+		recordFetcher := persist.FilesystemBankRecordIDIndex{
+			Root: filepath.Join(rootDir, index.RepoName, repository.BankRecordIDIndexDirectory),
+		}
+
+		fmt.Printf("ready to read from: %s", recordFetcher.Root)
+	},
+}
+
+func init() {
+	indexCmd.AddCommand(bankRecordIdCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// bankRecordIdCmd.PersistentFlags().String("foo", "", "A help for foo")
+	bankRecordIdCmd.PersistentFlags().StringP(briOutputFlag, briOutputShorthand, briOutputDefault, briOutputUsage)
+
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// bankRecordIdCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	bankRecordIdConfig.BindPFlags(bankRecordIdCmd.PersistentFlags())
+}

--- a/cmd/index_rebuild.go
+++ b/cmd/index_rebuild.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2020 Martin Strobel
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	deleteFirstFlag = "unsafe-pre-delete"
+	deleteFirstUsage = `Forgo the safety measure of rebuilding each index
+in a new file before overwriting the old copy.`
+)
+
+var rebuildConfig = viper.New()
+
+// rebuildCmd represents the rebuild command
+var rebuildCmd = &cobra.Command{
+	Use:   "rebuild",
+	Short: "Delete and reconstruct indices.",
+	Long: `Each index is a collection of files. These files list the transactions
+associated with some aspect of your transaction data. Like the index in a book,
+they offer to show you which page to turn to, not the actual data. In this way,
+they are fundamentally a redundant structure, and do not intrinsically store
+your data.
+
+This operation will re-traverse every transaction present in this repository,
+and rebuild from scratch each list of transactions. Once the operation is
+complete, the original index will be deleted. Depending on the number of
+transactions in your repository, this could be a time consuming endeavor.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("rebuild called")
+	},
+}
+
+func init() {
+	indexCmd.AddCommand(rebuildCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// rebuildCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	rebuildCmd.PersistentFlags().Bool(deleteFirstFlag, false, deleteFirstUsage)
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// rebuildCmd.Flags().BoolP("toggle", "t", false, "Help messasge for toggle")
+
+	err := rebuildConfig.BindPFlags(rebuildCmd.PersistentFlags())
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/marstr/baronial
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/marstr/envelopes v0.2.4
+	github.com/marstr/envelopes v0.2.5
 	github.com/marstr/units v1.0.1
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/marstr/collection v1.1.1 h1:NJgrWXrjYWkrAr/bAp6LVCT+NvrZpE8URGFy7R7CBIA=
 github.com/marstr/collection v1.1.1/go.mod h1:yGFnCtb7iWtkdragXuuvnQzBQ8DAu+awhmE7F4kRgaQ=
-github.com/marstr/envelopes v0.2.4 h1:49yL/tB4/+Xkz78MRsCO1IsZciPkrrNqV9ZyCGgiwoI=
-github.com/marstr/envelopes v0.2.4/go.mod h1:oGPRhVzOhygr7Zfmjw6sLVb22K3yPm/TWuuF3u8QVf8=
+github.com/marstr/envelopes v0.2.5 h1:YwIpUn2Pbu5u2DBxqAZZqr/1zGHakOOh0fichVKMmDM=
+github.com/marstr/envelopes v0.2.5/go.mod h1:oGPRhVzOhygr7Zfmjw6sLVb22K3yPm/TWuuF3u8QVf8=
 github.com/marstr/units v1.0.1 h1:J1oBku8rInztZY9IO0W2fS1bZ60UotlmBLbyvyZLoSU=
 github.com/marstr/units v1.0.1/go.mod h1:B1/IxDKETT7FwLuU0ZOvdPePP9chjt0PLTt+qeVARJ8=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/internal/format/transaction.go
+++ b/internal/format/transaction.go
@@ -60,8 +60,8 @@ func ConcisePrintTransaction(_ context.Context, output io.Writer, subject envelo
 	if err != nil {
 		return
 	}
-	if subject.RecordId != "" {
-		_, err = fmt.Fprintf(output, "\tBank Record ID:\t%s\n", subject.RecordId)
+	if subject.RecordID != "" {
+		_, err = fmt.Fprintf(output, "\tBank Record ID:\t%s\n", subject.RecordID)
 		if err != nil {
 			return err
 		}
@@ -117,8 +117,8 @@ func PrettyPrintTransaction(
 	if err != nil {
 		return err
 	}
-	if subject.RecordId != "" {
-		_, err = fmt.Fprintf(output, "Bank Record ID:\t%s\n", subject.RecordId)
+	if subject.RecordID != "" {
+		_, err = fmt.Fprintf(output, "Bank Record ID:\t%s\n", subject.RecordID)
 		if err != nil {
 			return err
 		}

--- a/internal/repository/location.go
+++ b/internal/repository/location.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Martin Strobel
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package repository
+
+import "os"
+
+const (
+	IndicesDirectory = "indices"
+	BankRecordIDIndexDirectory = IndicesDirectory + string(os.PathSeparator) + "bank_record_id"
+)


### PR DESCRIPTION
This generally adds the infrastructure necessary for indexing, and will also be instructive in how to dramatically speed up the log command for accounts that are rarely touched.