### PR TITLE
Use buster for Debian build

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,7 @@
-ARG tag=stretch
+ARG tag=buster
 
-FROM golang:${tag} AS builder
+FROM debian:${tag} AS builder
+RUN apt update; apt install -y golang perl make git
 
 WORKDIR /usr/local/src/baronial
 


### PR DESCRIPTION
Looks like the project will actually build with Go 1.11.6. That means we can use Debian 10 repositories to build the project.