### PR TITLE
Use GitHub Actions Upload-Actions v4 instead of the now deprecated v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         run: make linux
       - name: Test
         run: make test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Linux
           path: bin/linux/baronial
@@ -33,7 +33,7 @@ jobs:
         run: .\make.bat
       - name: Test
         run: go test -v ./...
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Windows
           path: bin/windows/baronial.exe
@@ -48,7 +48,7 @@ jobs:
         run: make darwin
       - name: Test
         run: make test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Darwin
           path: bin/darwin/baronial
@@ -62,11 +62,11 @@ jobs:
         - name: Build
           run: |
             make bin/linux/baronial.fc38.src.rpm bin/linux/baronial.fc38.x86_64.rpm
-        - uses: actions/upload-artifact@v2
+        - uses: actions/upload-artifact@v4
           with:
             name: baronial.fc38.src.rpm
             path: bin/linux/baronial.fc38.src.rpm
-        - uses: actions/upload-artifact@v2
+        - uses: actions/upload-artifact@v4
           with:
             name: baronial.fc38.x86_64.rpm
             path: bin/linux/baronial.fc38.x86_64.rpm
@@ -79,11 +79,11 @@ jobs:
       - name: Build
         run: |
           make bin/linux/baronial.fc39.src.rpm bin/linux/baronial.fc39.x86_64.rpm
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: baronial.fc39.src.rpm
           path: bin/linux/baronial.fc34.src.rpm
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: baronial.fc39.x86_64.rpm
           path: bin/linux/baronial.fc39.x86_64.rpm

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Test
         run: make test
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Linux
           path: bin/linux/baronial
@@ -42,7 +42,7 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Windows
           path: bin/windows/baronial.exe
@@ -56,7 +56,7 @@ jobs:
         run: make darwin
       - name: Test
         run: make test
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Baronial Darwin
           path: bin/darwin/baronial

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -52,6 +52,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.20.0'
       - name: Build
         run: make darwin
       - name: Test


### PR DESCRIPTION
The build is failing because of this: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

This PR naively attempts to fix it by just bumping the version numbers.