### PR TITLE
Overhaul Commit Amount Calculation Timing and Exposure

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -38,7 +38,7 @@ import (
 const (
 	amountFlag      = "amount"
 	amountShorthand = "a"
-	amountDefault   = "<calculated>"
+	amountDefault   = "<gross change>"
 	amountUsage     = "The magnitude of the transaction that should be displayed in logs."
 )
 
@@ -128,16 +128,6 @@ var commitCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-
-			var err error
-			commitTransactionFromFlags.Amount, err = calculateAmount(ctx, ".")
-			if err != nil {
-				logrus.Fatalf("Failed to calculate the amount from %q because of the following error: %s", amountDefault, err)
-			}
-
 		}
 
 		commitTransactionFromFlags.EnteredTime = time.Now()
@@ -151,6 +141,14 @@ var commitCmd = &cobra.Command{
 		targetDir, err := index.RootDirectory(".")
 		if err != nil {
 			logrus.Fatal(err)
+		}
+
+		if !cmd.Flags().Changed(amountFlag) {
+			var err error
+			commitTransactionFromFlags.Amount, err = calculateAmount(ctx, ".")
+			if err != nil {
+				logrus.Fatalf("Failed to calculate the amount from %q because of the following error: %s", amountDefault, err)
+			}
 		}
 
 		commitTransactionFromFlags.State, err = index.LoadState(ctx, targetDir)
@@ -388,9 +386,6 @@ func promptToContinue(ctx context.Context, message string, output io.Writer, inp
 }
 
 func calculateAmount(ctx context.Context, targetDir string) (envelopes.Balance, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
 	targetDir, err := index.RootDirectory(targetDir)
 	if err != nil {
 		return envelopes.Balance{}, err

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,6 +31,7 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 
+	"github.com/marstr/baronial/internal/format"
 	"github.com/marstr/baronial/internal/index"
 )
 
@@ -75,6 +75,13 @@ const (
 	forceShorthand = "f"
 	forceDefault   = false
 	forceUsage     = "Ignore warnings, commit the transaction anyway."
+)
+
+const (
+	dryrunFlag      = "dry-run"
+	dryrunShorthand = "d"
+	dryrunDefault   = false
+	dryrunUsage     = "Generates and prints a commit without writing it or updating any references."
 )
 
 const (
@@ -174,8 +181,8 @@ var commitCmd = &cobra.Command{
 				shouldContinue, err := promptToContinue(
 					ctx,
 					"proceed despite imbalance?",
-					os.Stdout,
-					os.Stdin)
+					cmd.OutOrStdout(),
+					cmd.InOrStdin())
 				if err != nil {
 					logrus.Fatal(err)
 				}
@@ -255,9 +262,43 @@ var commitCmd = &cobra.Command{
 		}
 		commitTransactionFromFlags.RecordID = envelopes.BankRecordID(rawRecordId)
 
-		err = persist.Commit(ctx, repo, commitTransactionFromFlags, additionalParents...)
+		var dryrun bool
+		dryrun, err = cmd.Flags().GetBool(dryrunFlag)
 		if err != nil {
 			logrus.Fatal(err)
+		}
+
+		if dryrun {
+			var head persist.RefSpec
+			head, err = repo.Current(ctx)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			var parent envelopes.ID
+			if head != "" {
+				parent, err = persist.Resolve(ctx, repo, head)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+			}
+
+			if parent.Equal(envelopes.ID{}) {
+				commitTransactionFromFlags.Parents = []envelopes.ID{}
+			} else {
+				commitTransactionFromFlags.Parents = append([]envelopes.ID{parent}, additionalParents...)
+			}
+
+			err = format.PrettyPrintTransaction(ctx, cmd.OutOrStdout(), repo, commitTransactionFromFlags)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+		} else {
+			err = persist.Commit(ctx, repo, commitTransactionFromFlags, additionalParents...)
+			if err != nil {
+				logrus.Fatal(err)
+			}
 		}
 	},
 }
@@ -272,6 +313,7 @@ func init() {
 	commitCmd.Flags().StringP(amountFlag, amountShorthand, amountDefault, amountUsage)
 	commitCmd.Flags().StringP(bankRecordIDFlag, bankRecordIDShorthand, bankRecordIDDefault, bankRecordIDUsage)
 	commitCmd.Flags().BoolP(forceFlag, forceShorthand, forceDefault, forceUsage)
+	commitCmd.Flags().BoolP(dryrunFlag, dryrunShorthand, dryrunDefault, dryrunUsage)
 }
 
 func promptToContinue(ctx context.Context, message string, output io.Writer, input io.Reader) (bool, error) {


### PR DESCRIPTION
This will eventually help with getting rid of the amount calculation that slows down the help text and can timeout on slow storage.

Fixes #122 